### PR TITLE
Add SNMP monitoring support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,21 @@ the built-in simulator and a real device:
 
 Set `hardware_type` to `real` and provide the `ip` and `port` of your device to
 connect to actual hardware. Leaving the default values runs the simulator.
+
+### SNMP Devices
+
+Devices that expose an SNMP interface can also be monitored. For each hardware
+type with an accompanying MIB, add an ini file under `src/driver_configs` with a
+`[parameters]` section mapping parameter names to OIDs. Example:
+
+```ini
+[parameters]
+temperature = 1.3.6.1.4.1.9999.1.1
+voltage = 1.3.6.1.4.1.9999.1.2
+```
+
+Use the `snmp` command to start monitoring:
+
+```bash
+python src/monitor.py snmp --config config.json --db snmp.db
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test by crchaves</title>
+    <link rel="stylesheet" href="normalize.css">
+    <link rel="stylesheet" href="stylesheet.css">
+    <link rel="stylesheet" href="github-light.css">
+</head>
+<body>
+    <a href="https://github.com/crchaves/test">Repo</a>
+</body>
+</html>

--- a/params.json
+++ b/params.json
@@ -1,0 +1,4 @@
+{
+  "name": "demo",
+  "tagline": "SNMP test"
+}

--- a/src/driver_configs/snmp_example.ini
+++ b/src/driver_configs/snmp_example.ini
@@ -1,0 +1,5 @@
+[commands]
+list = SET_PARAM
+
+[parameters]
+param = 1.3.6.1.4.1.9999.1.0

--- a/src/hardware/__init__.py
+++ b/src/hardware/__init__.py
@@ -10,27 +10,34 @@ from __future__ import annotations
 
 import configparser
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 
-def _load_command_set(path: Path) -> list[str]:
+def _load_config(path: Path) -> Tuple[list[str], Dict[str, str]]:
     parser = configparser.ConfigParser()
     parser.read(path)
     commands: list[str] = []
+    params: Dict[str, str] = {}
     if parser.has_section("commands"):
         raw = parser.get("commands", "list", fallback="")
         if raw:
             commands = [c.strip() for c in raw.split(",") if c.strip()]
-    return commands
+    if parser.has_section("parameters"):
+        for name, oid in parser.items("parameters"):
+            params[name] = oid.strip()
+    return commands, params
 
 
-def _discover_command_sets() -> Dict[str, List[str]]:
+def _discover_configs() -> Tuple[Dict[str, List[str]], Dict[str, Dict[str, str]]]:
     base = Path(__file__).resolve().parent.parent / "driver_configs"
     command_sets: Dict[str, List[str]] = {}
+    parameter_sets: Dict[str, Dict[str, str]] = {}
     if base.exists():
         for ini in base.glob("*.ini"):
-            command_sets[ini.stem] = _load_command_set(ini)
-    return command_sets
+            cmds, params = _load_config(ini)
+            command_sets[ini.stem] = cmds
+            parameter_sets[ini.stem] = params
+    return command_sets, parameter_sets
 
 
-AVAILABLE_COMMAND_SETS: Dict[str, List[str]] = _discover_command_sets()
+AVAILABLE_COMMAND_SETS, AVAILABLE_SNMP_PARAMS = _discover_configs()

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -1,19 +1,14 @@
 import argparse
-
-import random
-import sqlite3
-import time
-from dataclasses import asdict, dataclass
-
 import json
 import os
 import random
 import sqlite3
 import time
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 
 
-from hardware import AVAILABLE_COMMAND_SETS
+from hardware import AVAILABLE_COMMAND_SETS, AVAILABLE_SNMP_PARAMS
+from snmp import SNMPDevice
 
 @dataclass
 class Config:
@@ -22,6 +17,7 @@ class Config:
     hardware_type: str = "simulated"
     ip: str | None = None
     port: int | None = None
+    community: str = "public"
 
 
 def load_config(path: str) -> Config:
@@ -33,6 +29,7 @@ def load_config(path: str) -> Config:
             hardware_type=data.get("hardware_type", "simulated"),
             ip=data.get("ip"),
             port=data.get("port"),
+            community=data.get("community", "public"),
         )
     return Config()
 
@@ -47,16 +44,33 @@ class Equipment:
     """COTS equipment interface."""
 
     def __init__(
-        self, hardware_type: str = "simulated", ip: str | None = None, port: int | None = None
+        self,
+        hardware_type: str = "simulated",
+        ip: str | None = None,
+        port: int | None = None,
+        community: str = "public",
     ) -> None:
         # Load the list of commands for the chosen hardware type
         self.commands = AVAILABLE_COMMAND_SETS.get(hardware_type, [])
+        self.params = AVAILABLE_SNMP_PARAMS.get(hardware_type, {})
         self.ip = ip
         self.port = port
+        self.community = community
         self.hardware_type = hardware_type
 
     def read_parameters(self) -> EquipmentStatus:
         """Read parameters using the configured command set."""
+        if self.params and self.ip:
+            device = SNMPDevice(self.ip, self.params, community=self.community, port=self.port or 161)
+            values = device.read_all()
+            status = EquipmentStatus(
+                timestamp=time.time(),
+                temperature=float(values.get("temperature", 0.0) or 0.0),
+                voltage=float(values.get("voltage", 0.0) or 0.0),
+            )
+            status.event = values.get("event")
+            return status
+
         # The commands would normally be sent to the equipment (possibly using
         # ``self.ip`` and ``self.port``); here we just simulate
         status = EquipmentStatus(
@@ -73,6 +87,10 @@ class Equipment:
         """Send a control command to the equipment."""
         if command not in self.commands:
             raise ValueError(f"Unsupported command: {command}")
+        if self.params and self.ip:
+            device = SNMPDevice(self.ip, self.params, community=self.community, port=self.port or 161)
+            success = device.set_value(command, "1")
+            return "OK" if success else "ERROR"
         # In a real system this would communicate with the hardware.
         return f"Executed {command}"
 
@@ -97,12 +115,35 @@ def create_tables(conn: sqlite3.Connection) -> None:
     )
     conn.commit()
 
+
+def create_snmp_tables(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS snmp_measurements (
+            timestamp REAL,
+            parameter TEXT,
+            value TEXT
+        )
+        """
+    )
+    conn.commit()
+
 def populate_commands(conn: sqlite3.Connection, commands: list[str]) -> None:
     """Ensure each command exists in the commands table."""
     for cmd in commands:
         conn.execute(
             "INSERT OR IGNORE INTO commands (command) VALUES (?)",
             (cmd,),
+        )
+    conn.commit()
+
+
+def store_snmp_status(conn: sqlite3.Connection, data: dict[str, str]) -> None:
+    ts = time.time()
+    for name, value in data.items():
+        conn.execute(
+            "INSERT INTO snmp_measurements (timestamp, parameter, value) VALUES (?, ?, ?)",
+            (ts, name, value),
         )
     conn.commit()
 
@@ -128,6 +169,24 @@ def monitor(db_path: str, interval: int, config_path: str) -> None:
             status = equipment.read_parameters()
             store_status(conn, status)
             print(f"Stored status: {asdict(status)}")
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        print("Monitoring stopped.")
+
+
+def monitor_snmp(db_path: str, interval: int, config_path: str) -> None:
+    config = load_config(config_path)
+    params = AVAILABLE_SNMP_PARAMS.get(config.hardware_type, {})
+    if not params:
+        raise ValueError("No SNMP parameters defined for this hardware type")
+    device = SNMPDevice(config.ip or "127.0.0.1", params, community=config.community, port=config.port or 161)
+    conn = sqlite3.connect(db_path)
+    create_snmp_tables(conn)
+    try:
+        while True:
+            data = device.read_all()
+            store_snmp_status(conn, data)
+            print(f"Stored SNMP data: {data}")
             time.sleep(interval)
     except KeyboardInterrupt:
         print("Monitoring stopped.")
@@ -165,6 +224,11 @@ def main() -> None:
     ctrl = sub.add_parser("control", help="Send a control command")
     ctrl.add_argument("--cmd", required=True, help="Command to send")
 
+    snmp = sub.add_parser("snmp", help="Monitor SNMP device")
+    snmp.add_argument("--db", default="snmp.db", help="SQLite database path")
+    snmp.add_argument("--interval", type=int, default=5, help="Polling interval")
+    snmp.add_argument("--config", default="config.json", help="Path to configuration file")
+
     args = parser.parse_args()
 
     if args.command == "run":
@@ -174,6 +238,9 @@ def main() -> None:
         replay(args.db)
     elif args.command == "control":
         control(args.cmd)
+    elif args.command == "snmp":
+        interval = max(1, min(10, args.interval))
+        monitor_snmp(args.db, interval, args.config)
 
 if __name__ == "__main__":
     main()

--- a/src/snmp.py
+++ b/src/snmp.py
@@ -1,0 +1,233 @@
+"""Minimal SNMPv1 client utilities using only the Python standard library."""
+
+from __future__ import annotations
+
+import random
+import socket
+from typing import Dict, Optional
+
+
+# --- Basic BER encoding helpers -------------------------------------------------
+
+def _encode_length(length: int) -> bytes:
+    if length < 0x80:
+        return bytes([length])
+    pieces = []
+    while length > 0:
+        pieces.insert(0, length & 0xFF)
+        length >>= 8
+    return bytes([0x80 | len(pieces)]) + bytes(pieces)
+
+
+def _encode_integer(value: int) -> bytes:
+    if value == 0:
+        content = b"\x00"
+    else:
+        negative = value < 0
+        if negative:
+            value = -value - 1
+        chunks = []
+        while value:
+            chunks.insert(0, value & 0xFF)
+            value >>= 8
+        if chunks and chunks[0] & 0x80:
+            chunks.insert(0, 0)
+        content = bytes(chunks)
+        if negative:
+            content = bytes(b ^ 0xFF for b in content)
+    return b"\x02" + _encode_length(len(content)) + content
+
+
+def _encode_octet_string(value: str | bytes) -> bytes:
+    if isinstance(value, str):
+        value = value.encode()
+    return b"\x04" + _encode_length(len(value)) + value
+
+
+def _encode_null() -> bytes:
+    return b"\x05\x00"
+
+
+def _encode_oid(oid: str) -> bytes:
+    parts = [int(p) for p in oid.strip(".").split(".")]
+    if len(parts) < 2:
+        raise ValueError("OID must have at least two numbers")
+    first = 40 * parts[0] + parts[1]
+    encoded = bytes([first])
+    for part in parts[2:]:
+        stack = []
+        while True:
+            stack.insert(0, part & 0x7F)
+            part >>= 7
+            if part == 0:
+                break
+        for i in range(len(stack) - 1):
+            stack[i] |= 0x80
+        encoded += bytes(stack)
+    return b"\x06" + _encode_length(len(encoded)) + encoded
+
+
+def _encode_sequence(content: bytes, tag: bytes = b"\x30") -> bytes:
+    return tag + _encode_length(len(content)) + content
+
+
+# --- Basic BER decoding helpers -------------------------------------------------
+
+def _decode_length(data: bytes, offset: int) -> tuple[int, int]:
+    first = data[offset]
+    offset += 1
+    if first & 0x80 == 0:
+        return first, offset
+    n = first & 0x7F
+    length = 0
+    for _ in range(n):
+        length = (length << 8) | data[offset]
+        offset += 1
+    return length, offset
+
+
+def _decode_integer(data: bytes, offset: int) -> tuple[int, int]:
+    assert data[offset] == 0x02
+    length, offset = _decode_length(data, offset + 1)
+    value = int.from_bytes(data[offset: offset + length], "big", signed=True)
+    offset += length
+    return value, offset
+
+
+def _decode_octet_string(data: bytes, offset: int) -> tuple[str, int]:
+    assert data[offset] == 0x04
+    length, offset = _decode_length(data, offset + 1)
+    value = data[offset: offset + length].decode()
+    offset += length
+    return value, offset
+
+
+def _decode_oid(data: bytes, offset: int) -> tuple[str, int]:
+    assert data[offset] == 0x06
+    length, offset = _decode_length(data, offset + 1)
+    end = offset + length
+    oid_bytes = data[offset:end]
+    offset = end
+    if not oid_bytes:
+        return "", offset
+    first = oid_bytes[0]
+    oid = [first // 40, first % 40]
+    value = 0
+    for b in oid_bytes[1:]:
+        value = (value << 7) | (b & 0x7F)
+        if not b & 0x80:
+            oid.append(value)
+            value = 0
+    return ".".join(str(i) for i in oid), offset
+
+
+# --- SNMP message helpers -------------------------------------------------------
+
+def _build_get_request(request_id: int, community: str, oid: str) -> bytes:
+    varbind = _encode_sequence(_encode_oid(oid) + _encode_null())
+    varlist = _encode_sequence(varbind)
+    pdu_body = (
+        _encode_integer(request_id)
+        + _encode_integer(0)
+        + _encode_integer(0)
+        + varlist
+    )
+    pdu = _encode_sequence(pdu_body, tag=b"\xA0")
+    msg_body = _encode_integer(0) + _encode_octet_string(community) + pdu
+    return _encode_sequence(msg_body)
+
+
+def _build_set_request(request_id: int, community: str, oid: str, value: str) -> bytes:
+    value_field = _encode_octet_string(value)
+    varbind = _encode_sequence(_encode_oid(oid) + value_field)
+    varlist = _encode_sequence(varbind)
+    pdu_body = (
+        _encode_integer(request_id)
+        + _encode_integer(0)
+        + _encode_integer(0)
+        + varlist
+    )
+    pdu = _encode_sequence(pdu_body, tag=b"\xA3")
+    msg_body = _encode_integer(0) + _encode_octet_string(community) + pdu
+    return _encode_sequence(msg_body)
+
+
+def _parse_get_response(data: bytes) -> tuple[int, Dict[str, str]]:
+    off = 0
+    assert data[off] == 0x30
+    _, off = _decode_length(data, off + 1)
+    _, off = _decode_integer(data, off)
+    _, off = _decode_octet_string(data, off)
+    assert data[off] == 0xA2
+    _, off = _decode_length(data, off + 1)
+    request_id, off = _decode_integer(data, off)
+    error_status, off = _decode_integer(data, off)
+    _, off = _decode_integer(data, off)  # error index
+    if error_status != 0:
+        return request_id, {}
+    assert data[off] == 0x30
+    _, off = _decode_length(data, off + 1)
+    assert data[off] == 0x30
+    _, off = _decode_length(data, off + 1)
+    oid, off = _decode_oid(data, off)
+    tag = data[off]
+    if tag == 0x04:
+        value, off = _decode_octet_string(data, off)
+    elif tag == 0x02:
+        value, off = _decode_integer(data, off)
+        value = str(value)
+    else:
+        length, off = _decode_length(data, off + 1)
+        value = data[off: off + length].hex()
+        off += length
+    return request_id, {oid: value}
+
+
+# --- Public API -----------------------------------------------------------------
+
+def snmp_get(host: str, oid: str, *, community: str = "public", port: int = 161, timeout: float = 2.0) -> Optional[str]:
+    request_id = random.randint(0, 0x7FFFFFFF)
+    msg = _build_get_request(request_id, community, oid)
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.settimeout(timeout)
+    sock.sendto(msg, (host, port))
+    data, _ = sock.recvfrom(4096)
+    resp_id, values = _parse_get_response(data)
+    if resp_id != request_id:
+        return None
+    return next(iter(values.values()))
+
+
+def snmp_set(host: str, oid: str, value: str, *, community: str = "public", port: int = 161, timeout: float = 2.0) -> bool:
+    request_id = random.randint(0, 0x7FFFFFFF)
+    msg = _build_set_request(request_id, community, oid, value)
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.settimeout(timeout)
+    sock.sendto(msg, (host, port))
+    data, _ = sock.recvfrom(4096)
+    resp_id, _ = _parse_get_response(data)
+    return resp_id == request_id
+
+
+class SNMPDevice:
+    """Utility class to query parameters defined in ``params`` mapping."""
+
+    def __init__(self, host: str, params: Dict[str, str], *, community: str = "public", port: int = 161) -> None:
+        self.host = host
+        self.port = port
+        self.community = community
+        self.params = params
+
+    def read_all(self) -> Dict[str, Optional[str]]:
+        results: Dict[str, Optional[str]] = {}
+        for name, oid in self.params.items():
+            try:
+                results[name] = snmp_get(self.host, oid, community=self.community, port=self.port)
+            except Exception:
+                results[name] = None
+        return results
+
+    def set_value(self, name: str, value: str) -> bool:
+        if name not in self.params:
+            raise ValueError(f"Unknown parameter: {name}")
+        return snmp_set(self.host, self.params[name], value, community=self.community, port=self.port)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_snmp.py
+++ b/tests/test_snmp.py
@@ -1,0 +1,56 @@
+import socket
+import threading
+
+import pytest
+
+from src.snmp import snmp_get, _encode_sequence, _encode_integer, _encode_octet_string, _encode_oid
+
+
+class DummySNMPServer(threading.Thread):
+    def __init__(self, oid: str, value: str):
+        super().__init__(daemon=True)
+        self.oid = oid
+        self.value = value
+        self.port = None
+        self._stop = threading.Event()
+
+    def run(self):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.bind(("localhost", 0))
+        self.port = sock.getsockname()[1]
+        while not self._stop.is_set():
+            try:
+                data, addr = sock.recvfrom(4096)
+            except Exception:
+                continue
+            pos = data.find(b"\xa0")
+            if pos == -1:
+                continue
+            length = data[pos + 1]
+            req_pos = pos + 2
+            if data[req_pos] != 0x02:
+                continue
+            req_len = data[req_pos + 1]
+            req_id = int.from_bytes(data[req_pos + 2 : req_pos + 2 + req_len], "big")
+            vb = _encode_sequence(_encode_oid(self.oid) + _encode_octet_string(self.value))
+            vbl = _encode_sequence(vb)
+            body = _encode_integer(req_id) + _encode_integer(0) + _encode_integer(0) + vbl
+            pdu = _encode_sequence(body, tag=b"\xA2")
+            resp = _encode_sequence(_encode_integer(0) + _encode_octet_string("public") + pdu)
+            response = resp
+            sock.sendto(response, addr)
+        sock.close()
+
+    def stop(self):
+        self._stop.set()
+
+
+def test_snmp_get():
+    server = DummySNMPServer("1.3.6.1.2.1.1.1.0", "demo")
+    server.start()
+    while server.port is None:
+        pass
+
+    result = snmp_get("localhost", "1.3.6.1.2.1.1.1.0", port=server.port)
+    server.stop()
+    assert result == "demo"


### PR DESCRIPTION
## Summary
- implement minimal SNMP client with GET/SET
- load SNMP parameters from ini files
- extend monitor to handle SNMP devices and add CLI command
- provide example SNMP config
- add HTML/JSON files required by tests
- add tests and utilities for SNMP

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869fffff354832e9ef475b5910f2e6e