### PR TITLE
Add NMEA TCP driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,3 +154,17 @@ with AISDriver("127.0.0.1", 10110) as drv:
     print(message)
 ```
 
+
+### NMEA Driver
+
+`NMEADriver` connects to a TCP source that streams NMEA 0183 navigation
+sentences such as ``GGA``, ``GLL`` and ``GSA``. Provide the IP address and port
+of the feed:
+
+```python
+from src.nmea_driver import NMEADriver
+
+with NMEADriver("192.168.1.10", 5000) as drv:
+    sentence = drv.read_sentence({"GGA", "GLL", "GSA"})
+    print(sentence)
+```

--- a/src/nmea_driver.py
+++ b/src/nmea_driver.py
@@ -1,0 +1,73 @@
+"""Minimal driver to read navigation NMEA sentences from a TCP stream."""
+from __future__ import annotations
+
+import socket
+from typing import Optional, Iterable
+
+
+class NMEADriver:
+    """Receive NMEA0183 sentences over a TCP connection."""
+
+    def __init__(self, host: str, port: int, timeout: float = 5.0) -> None:
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self._sock: Optional[socket.socket] = None
+        self._buffer = b""
+
+    def connect(self) -> None:
+        """Open the socket connection to the NMEA feed."""
+        if self._sock is not None:
+            return
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(self.timeout)
+        sock.connect((self.host, self.port))
+        self._sock = sock
+
+    def close(self) -> None:
+        """Close the socket connection."""
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            finally:
+                self._sock = None
+
+    def read_sentence(self, allowed: Optional[Iterable[str]] = None) -> Optional[str]:
+        """Read a single NMEA sentence from the stream.
+
+        Parameters
+        ----------
+        allowed:
+            Optional iterable of 3-letter sentence identifiers to filter. If
+            provided, sentences that don't match are skipped until a matching one
+            is read.
+        """
+        if self._sock is None:
+            raise RuntimeError("Driver is not connected")
+        allowed_set = {s.upper() for s in allowed} if allowed else None
+        while True:
+            while b"\n" not in self._buffer:
+                data = self._sock.recv(4096)
+                if not data:
+                    return None
+                self._buffer += data
+            line, self._buffer = self._buffer.split(b"\n", 1)
+            sentence = line.strip().decode()
+            if not sentence:
+                continue
+            if allowed_set:
+                # Sentence type is characters 3-5 after the '$' prefix
+                name = sentence.lstrip("$")[:5]
+                msg_id = name[2:5] if len(name) >= 5 else name
+                if msg_id.upper() not in allowed_set:
+                    continue
+            return sentence
+
+    def __enter__(self) -> "NMEADriver":
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+__all__ = ["NMEADriver"]

--- a/tests/test_nmea_driver.py
+++ b/tests/test_nmea_driver.py
@@ -1,0 +1,42 @@
+import socket
+import threading
+
+from src.nmea_driver import NMEADriver
+
+
+class DummyNMEAServer(threading.Thread):
+    def __init__(self, sentence: str):
+        super().__init__(daemon=True)
+        self.sentence = sentence
+        self.port = None
+        self._stop = threading.Event()
+
+    def run(self) -> None:
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.bind(("localhost", 0))
+        self.port = server.getsockname()[1]
+        server.listen(1)
+        conn, _ = server.accept()
+        data = self.sentence.encode() + b"\n"
+        conn.sendall(data)
+        conn.close()
+        server.close()
+        self._stop.set()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+
+def test_read_sentence() -> None:
+    sentence = "$GPGGA,1234,N,5678,E,1,08,1.0,10,M,,,*47"
+    server = DummyNMEAServer(sentence)
+    server.start()
+    while server.port is None:
+        pass
+
+    driver = NMEADriver("localhost", server.port)
+    with driver:
+        result = driver.read_sentence({"GGA", "GLL", "GSA"})
+    server.stop()
+
+    assert result == sentence


### PR DESCRIPTION
## Summary
- add `NMEADriver` to read navigation NMEA sentences from a TCP stream
- document new driver in the README
- test NMEA driver with a dummy TCP server

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_686a08e80468832ead3d2ee63adbdaf8